### PR TITLE
URI rewrite plus documentation

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,37 @@
+name: build-and-test
+
+on:
+  push:
+    # all branches
+  pull_request:
+    # all branches
+
+  # This enables the Run Workflow button on the Actions tab.
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Install Open Dylan
+        uses: dylan-lang/install-opendylan@v3
+
+      - name: Install dependencies
+        run: deft update
+
+      - name: Build and Run Tests
+        run: |
+          mkdir -p _build  # can't redirect without it
+          deft test -- --progress none --report surefire > _build/TEST-uri.xml
+
+      - name: Publish Test Report
+        if: success() || failure()
+        uses: mikepenz/action-junit-report@v5
+        with:
+          report_paths: '**/_build/TEST-*.xml'

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,0 +1,56 @@
+name: Build base64 documentation
+
+on:
+  push:
+    # all branches
+    paths:
+      - 'documentation/**'
+
+  # This enables the Run Workflow button on the Actions tab.
+  workflow_dispatch:
+
+# https://github.com/JamesIves/github-pages-deploy-action#readme
+permissions:
+    contents: write
+
+# Set DYLAN environment variable to GITHUB_WORKSPACE so packages are
+# installed in ../../_packages relative to documentation's Makefile
+env:
+  DYLAN: ${{ github.workspace }}
+
+jobs:
+
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Check Links
+        uses: addnab/docker-run-action@v3
+        with:
+          image: ghcr.io/fraya/dylan-docs
+          options: -v ${{ github.workspace }}/doc:/docs
+          run: make linkcheck
+
+      - name: Build Docs with Furo Theme
+        uses: addnab/docker-run-action@v3
+        with:
+          image: ghcr.io/fraya/dylan-docs
+          options: -v ${{ github.workspace }}/doc:/docs
+          run: make html
+
+      - name: Upload HTML Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: uri-doc-html
+          path: doc/build/html/
+
+      - name: Bypassing Jekyll on GH Pages
+        run: sudo touch doc/build/html/.nojekyll
+
+      - name: Deploy Documents to GH Pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: doc/build/html

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,0 +1,40 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+import os, sys
+sys.path.insert(0, os.path.abspath('../../_packages/sphinx-extensions/current/src/sphinxcontrib'))
+import dylan.domain
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'URI'
+copyright = '2026'
+author = 'Dylan Hackers'
+
+version = '2.0.0'
+release = version
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    'dylan.domain',
+]
+
+templates_path = ['_templates']
+exclude_patterns = []
+
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+
+html_static_path = ['_static']
+
+# -- Standard settings for Dylan documentation --------------------------
+primary_domain = 'dylan'
+html_theme = 'furo'

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,0 +1,414 @@
+***
+URI
+***
+
+The URI library exports interfaces to represent and manipulate Uniform Resource
+Identifiers (URIs) as described in `RFC 3986
+<https://datatracker.ietf.org/doc/html/rfc3986>`_.
+
+.. toctree::
+   :hidden:
+   :maxdepth: 2
+
+.. current-library:: uri
+.. current-module:: uri
+
+Overview
+========
+
+The primary class exported by the URI library is :class:`<uri>`.  URIs are usually
+created with :func:`string-to-uri`, and converted back to a string (e.g., for display or
+for transmission over the network) via :func:`uri-to-string`.
+
+URIs are immutable objects and all functions for retrieving elements of the URI such as
+host and path start with a ``uri-`` prefix: :gf:`uri-host`, :gf:`uri-port`, etc.
+
+Many characters in a URI may be "percent encoded" to remove ambiguity in parsing and to
+encode non-ASCII characters when sending over the network.  The functions in this module
+named with a ``uri-raw-`` prefix return these percent encoded strings and functions
+without "raw" in the name return "decoded" strings.
+
+
+
+The URI module
+==============
+
+.. constant:: <string?>
+
+   This is a non-exported constant that is equivalent to ``false-or(<string>)``. It is
+   used here solely to reduce the verbosity of this documentation since most
+   :class:`<uri>` methods use this type.
+
+Errors
+------
+
+.. class:: <uri-error>
+
+   :superclasses: :drm:`<simple-error>`
+
+   All errors explicitly signaled by the URI module are instances of this class.
+
+.. class:: <uri-parse-error>
+
+   :superclasses: :class:`<uri-error>`
+
+   All errors explicitly signaled by :func:`string-to-uri` are instances of this class.
+
+URI Class
+---------
+
+.. class:: <uri>
+   :open:
+
+   :superclasses: :drm:`<object>`
+
+   :keyword scheme: An instance of :const:`<string?>`.
+   :keyword user-info: An instance of :const:`<string?>`.
+   :keyword raw-user-info: An instance of :const:`<string?>`.
+   :keyword host: An instance of :const:`<string?>`.
+   :keyword raw-host: An instance of :const:`<string?>`.
+   :keyword port: An instance of :const:`<integer?>`.
+   :keyword path: An instance of :drm:`<list>`.
+   :keyword raw-path: An instance of :const:`<string?>`.
+   :keyword query: An instance of ``false-or(<string-table>)``.
+   :keyword raw-query: An instance of :const:`<string?>`.
+   :keyword fragment: An instance of :const:`<string?>`.
+   :keyword raw-fragment: An instance of :const:`<string?>`.
+
+   This class represents a URI that has been decomposed into its constituent parts.
+   Instances should generally be created via :func:`string-to-uri`.  When calling
+   :drm:`make` directly it is only necessary to supply either the "raw" (percent encoded)
+   or "non-raw" (percent decoded) init value; the other value will be computed if
+   accessed.
+
+Convert to/from Strings
+-----------------------
+
+.. function:: string-to-uri
+
+   :signature: string-to-uri(*string* :: :drm:`<string>`) => (*uri* :: :class:`<uri>`)
+
+   Parse *string*, the string representation of a URI, into its component parts and
+   return it as a :class:`<uri>`.
+
+.. function:: split-uri
+
+   :signature: split-uri (*string* :: :drm:`<string>`) => (*scheme* ::
+               :const:`<string?>`, *user-info* :: :const:`<string?>`, *host* ::
+               :const:`<string?>`, *port* :: :const:`<string?>`, *path* ::
+               :const:`<string?>`, *query* :: :const:`<string?>`, *fragment* ::
+               :const:`<string?>`)
+
+   Splits *string* into its component parts. Except for *port*, which is an
+   :const:`<integer?>`, all values are instances of :const:`<string?>` which have *not*
+   been percent decoded.  That is, assuming the original *string* was percent encoded,
+   the return values are appropriate for using as the ``raw-*`` init arguments to
+   ``make(<uri>)``.
+
+   This function is used by :gf:`string-to-uri` and is intended to be used by subclassers
+   of :class:`<uri>` for purposes of instance creation if they need to provide additional
+   initialization arguments.
+
+.. function:: uri-to-string
+
+   :signature: uri-to-string (*uri* :: :class:`<uri>`, #key *scheme?* :: :drm:`<boolean>`, *authority?* :: :drm:`<boolean>`) => (*string* :: :drm:`<string>`)
+
+   Returns the percent encoded string representation of *uri*.  *scheme?* and
+   *authority?* both default to true.
+
+URI Components
+--------------
+
+.. generic-function:: uri-scheme
+
+   :signature: uri-scheme (*uri* :: :class:`<uri>`) => (*scheme* :: :const:`<string?>`)
+
+   If *uri* has a scheme part, this function returns it as a :drm:`<string>`, otherwise
+   it returns :drm:`#f`.  If *uri* was created by :func:`string-to-uri` the scheme will
+   be all lowercase.  Example:
+
+   .. code:: dylan-repl
+
+      ? string-to-uri("S://u:pw@h:77/p?q#f").uri-scheme
+      $0 = "s"
+
+.. generic-function:: uri-user-info
+
+   :signature: uri-user-info (*uri* :: :class:`<uri>`) => (*info* :: :const:`<string?>`)
+
+   Returns the user-info component of *uri* as a percent decoded string, or :drm:`#f`.
+   Example:
+
+   .. code:: dylan-repl
+
+      ? string-to-uri("S://u:p%40ss@h:77/p?q#f").uri-user-info
+      $0 = "u:p@ss"
+
+.. generic-function:: uri-raw-user-info
+
+   :signature: uri-raw-user-info (*uri* :: :class:`<uri>`) => (*info* :: :const:`<string?>`)
+
+   Returns the user-info component of *uri* as a percent encoded string, or :drm:`#f`.
+   Example:
+
+   .. code:: dylan-repl
+
+      ? string-to-uri("S://u:p%40ss@h:77/p?q#f").uri-raw-user-info
+      $0 = "u:p%40ss"
+
+.. generic-function:: uri-host
+
+   :signature: uri-host (*uri* :: :class:`<uri>`) => (*host* :: :const:`<string?>`)
+
+   Returns the host component of *uri* as a percent decoded string, or :drm:`#f`.
+   Example:
+
+   .. code:: dylan-repl
+
+      ? string-to-uri("S://u:pw@h%71:77/p?q#f").uri-host
+      $0 = "hq"
+
+.. generic-function:: uri-raw-host
+
+   :signature: uri-raw-host (*uri* :: :class:`<uri>`) => (*host* :: :const:`<string?>`)
+
+   Returns the host component of *uri* as a percent encoded string, or :drm:`#f`.
+   Example:
+
+   .. code:: dylan-repl
+
+      ? string-to-uri("S://u:pw@h%71:77/p?q#f").uri-raw-host
+      $0 = "h%71"
+
+.. generic-function:: uri-port
+
+   :signature: uri-port (*uri* :: :class:`<uri>`) => (*port* :: :const:`<integer?>`)
+
+   Returns the port component of *uri* as an integer, or :drm:`#f`. Example:
+
+   .. code:: dylan-repl
+
+      ? string-to-uri("S://u:pw@h:77/p?q#f").uri-port
+      $0 = 77
+
+.. generic-function:: uri-authority
+
+   :signature: uri-authority (*uri* :: :class:`<uri>`, #key *percent-encoded?* ::
+               :drm:`<boolean>`) => (*authority* :: :const:`<string?>`)
+
+   Returns the port component of *uri* as a string, or :drm:`#f`. If *percent-encoded?*
+   is true the returned string is percent encoded. The default is false. Example:
+
+   If *uri* has an authority part, this function returns it as a :drm:`<string>`,
+   otherwise it returns :drm:`#f`. Example:
+
+   .. code:: dylan-repl
+
+      ? string-to-uri("s://u:pw@h:77/p?q#f").uri-authority
+      $0 = "u:pw@h:77"
+
+   Note that per `RFC 3986
+   <https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.3>`_,
+
+     "URI producers and normalizers should omit the port component and its ':' delimiter
+     if port is empty or if its value would be the same as that of the scheme's default."
+
+   Accordingly, for example, ``uri-authority(string-to-uri("https://foo.org:443"))``
+   returns ``"foo.org"``, not ``"foo.org:443"``.
+
+.. generic-function:: uri-path
+   :open:
+
+   :signature: uri-path (*uri* :: :class:`<uri>`) => (*path* :: :drm:`<object>`)
+
+   Returns the percent decoded path component of *uri*, or :drm:`#f`.
+
+.. method:: uri-path
+   :specializer: <uri>
+
+   Returns the percent decoded path component of *uri* as a list of percent decoded path
+   segments.  The list is created by ``split(raw-path, '/')``, therefore it will contain
+   an empty string as the first element if the path starts with "/".  If there is no
+   path, ``#()`` is returned.
+
+   Example:
+
+   .. code:: dylan-repl
+
+      ? string-to-uri("S://u:pw@h:77/p?q#f").uri-path
+      $0 = #("", "p")
+
+.. generic-function:: uri-raw-path
+
+   :signature: uri-raw-path (*uri* :: :class:`<uri>`) => (*path* :: :const:`<string?>`)
+
+   Returns the path component of *uri* as a percent encoded string, or :drm:`#f`.
+   Example:
+
+   .. code:: dylan-repl
+
+      ? string-to-uri("S://u:pw@h:77/p?q#f").uri-raw-path
+      $0 = "/p"
+
+.. generic-function:: uri-query
+   :open:
+
+   :signature: uri-query (*uri* :: :class:`<uri>`) => (*qvalues* :: :drm:`<object>`)
+
+   Returns the query component of *uri*.
+
+.. method:: uri-query
+   :specializer: <uri>
+
+   :signature: uri-query (*uri* :: :class:`<uri>`) => (*qvalues* :: ``false-or(<string-table>``)
+
+   Returns the query part of a URI as a table mapping query keys to their corresponding
+   (percent decoded) values.  For example, for the query string ``"a=1&b=%40&c&c=&c=v"``
+   the returned table looks like this:
+
+   +---------+---------------------+
+   |   Key   | Value               |
+   +=========+=====================+
+   | ``"a"`` | ``"1"``             |
+   +---------+---------------------+
+   | ``"b"`` | ``"@"``             |
+   +---------+---------------------+
+   | ``"c"`` | ``#("", "v", #t)``  |
+   +---------+---------------------+
+
+   Notice,
+
+   1. The value associated with "b" was percent decoded.
+   2. "c" appeared multiple times so its value is a list.
+   3. The value associated with "c=" is the empty string.
+   4. The value associated with "c" (with no "=") is :drm:`#t`.
+   5. The order of the "c" list is not guaranteed; if you depend on it your code may
+      break in a future release.
+
+   .. code:: dylan-repl
+
+      ? string-to-uri("S://u:pw@h:77/p?q=1#f").uri-query
+      $0 = {<string-table> size: 1}
+      ? uri-query-value($0, "q")
+      $1 = "1"
+
+   It is recommended to use :gf:`uri-query-value` instead of accessing the
+   :gf:`uri-query` table directly.
+
+.. generic-function:: uri-raw-query
+
+   :signature: uri-raw-query (*uri* :: :class:`<uri>`) => (*query* :: :const:`<string?>`)
+
+   .. code:: dylan-repl
+
+      ? string-to-uri("S://u:pw@h:77/p?q%26=2#f").uri-raw-query
+      $0 = "q%26=2"
+
+.. generic-function:: uri-query-value
+   :open:
+
+   :signature: uri-query-value (*uri* :: :class:`<uri>`, *key* :: :drm:`<string>`, #key *all?* :: :drm:`<boolean>`) => (*value* :: :drm:`<object>`)
+
+.. method:: uri-query-value
+   :specializer: <uri>
+
+   :signature: uri-query-value (*uri* :: :class:`<uri>`, *key* :: :drm:`<string>`, #key *all?* :: :drm:`<boolean>`) => (*value* :: :drm:`<object>`)
+
+   This method provides an easier and more future-proof way to access individual query
+   values, rather than directly accessing the :class:`<string-table>` returned by
+   :gf:`uri-query`.
+
+   By default :gf:`uri-query-value` returns a single string or :drm:`#t`, i.e., if *key*
+   maps to a list of values (see :gf:`uri-query`) one of the values is chosen
+   arbitrarily.  With ``all?: #t`` the entire list is returned.
+
+.. generic-function:: uri-fragment
+
+   :signature: uri-fragment (*uri* :: :class:`<uri>`) => (*fragment* :: :const:`<string?>`)
+
+   .. code:: dylan-repl
+
+      ? string-to-uri("S://u:pw@h:77/p?q#f%40").uri-fragment
+      $0 = "f@"
+
+.. generic-function:: uri-raw-fragment
+
+   :signature: uri-raw-fragment (*uri* :: :class:`<uri>`) => (*fragment* :: :const:`<string?>`)
+
+   .. code:: dylan-repl
+
+      ? string-to-uri("S://u:pw@h:77/p?q#f%40").uri-raw-fragment
+      $0 = "f%40"
+
+.. function:: uri-relative?
+
+   :signature: uri-relative? (*uri* :: :class:`<uri>`) => (*relative?* :: :drm:`<boolean>`)
+
+   Essentially a URI is relative if it does not have a scheme.  See `the URI RFC
+   <https://datatracker.ietf.org/doc/html/rfc3986#section-4.1>`_ for details.
+
+Merging URIs
+------------
+
+.. generic-function:: merge-uris
+   :open:
+
+   :signature: merge-uris (*base* :: :class:`<uri>`, *reference* :: :class:`<uri>`, #key *strict?* :: :drm:`<boolean>`) => (*merged* :: :class:`<uri>`)
+
+Normalization and Comparison
+----------------------------
+
+`URI normalization and comparison
+<https://datatracker.ietf.org/doc/html/rfc3986#section-6>`_ are not yet implemented.
+
+Percent Encoding
+----------------
+
+.. generic-function:: percent-encode
+
+   :signature: percent-encode (*string* :: :drm:`<byte-string>`, *charset* :: :drm:`<table>`) => (*encoded-string* :: :drm:`<byte-string>`)
+
+   Returns a :drm:`<string>` in which any character in *string* that isn't part of
+   *charset* is percent encoded.  *charset* is typically one of the character sets
+   documented below, depending on what component of a URI is being percent encoded.
+
+.. constant:: $charset-user-info
+
+   The character set comprised of all characters that are valid in the user-info
+   component of a URI.
+
+.. constant:: $charset-host
+
+   The character set comprised of all characters that are valid in the host component of
+   a URI.
+
+.. constant:: $charset-path
+
+   The character set comprised of all characters that are valid in the path component of
+   a URI.
+
+.. constant:: $charset-query
+
+   The character set comprised of all characters that are valid in the query component of
+   a URI.
+
+.. constant:: $charset-fragment
+
+   The character set comprised of all characters that are valid in the fragment component
+   of a URI.
+
+.. generic-function:: percent-decode
+
+   :signature: percent-decode (*string* :: :drm:`<byte-string>`, #key *strict?* :: :drm:`<boolean>`) => (*unencoded* :: :drm:`<byte-string>`)
+
+   Returns a :drm:`<string>` in which any percent escape sequence (e.g., "%40") is
+   replaced by the character with the corresponding hex value.  For example,
+
+   .. code:: dylan-repl
+
+      ? percent-decode("a%40b")
+      $0 = "a@b"
+
+   If *strict?* is true, an error will be signaled for invalid percent encodings such as
+   "100%" or "a % b".  The default is false, meaning to simply include a literal "%" in
+   the result.

--- a/dylan-package.json
+++ b/dylan-package.json
@@ -1,7 +1,7 @@
 {
     "name": "uri",
     "version": "1.0.1",
-    "description": "A library to represent, parse, and compose URIs",
+    "description": "Uniform Resource Identifiers (URIs) per RFC 3986",
     "dependencies": [
         "strings@1.2"
     ],

--- a/dylan-package.json
+++ b/dylan-package.json
@@ -1,7 +1,7 @@
 {
     "name": "uri",
     "version": "1.0.1",
-    "description": "A class to represent, parse, and compose URIs",
+    "description": "A library to represent, parse, and compose URIs",
     "dependencies": [
         "strings@1.2"
     ],

--- a/sources/library.dylan
+++ b/sources/library.dylan
@@ -2,47 +2,56 @@ module: dylan-user
 
 define library uri
   use common-dylan;
-  use collection-extensions;
   use io;
   use system;
   use strings;
 
   export uri;
-end;
+end library;
 
 define module uri
-  use common-dylan,
-    exclude: { format-to-string };
-  use format;
-  use streams,
-    import: { <byte>, <byte-character> };
-  use strings;
+  // Errors
+  create
+    <uri-error>,
+    <uri-parse-error>;
 
-  export
-    <uri>, <url>,
-    uri-scheme, uri-scheme-setter,
-    uri-userinfo, uri-userinfo-setter,
-    uri-host, uri-host-setter,
-    uri-port, uri-port-setter,
-    uri-path, uri-path-setter,
-    uri-query, uri-query-setter,
-    uri-fragment, uri-fragment-setter,
-    uri-authority /* not defined --cgay   uri-authority-setter */;
-  export
-    parse-uri, parse-url,
-    build-uri, transform-uris,
-    build-path, build-query;
-  export
-    remove-dot-segments,
-    split-path,
-    split-query;
-  export
-    absolute?,
-    relative?;
-  export
+  // Creation and conversion
+  create
+    merge-uris,
+    split-uri,
+    string-to-uri,
+    uri-to-string;
+
+  // URI class and getters
+  create
+    <uri>,
+    uri-scheme,
+    uri-user-info, uri-raw-user-info,
+    uri-host, uri-raw-host,
+    uri-port,
+    uri-authority,
+    uri-path, uri-raw-path,
+    uri-query, uri-raw-query, uri-query-value,
+    uri-fragment, uri-raw-fragment,
+    uri-relative?;
+
+  // Percent encoding
+  create
     percent-encode,
     percent-decode,
-    $uri-pchar;
-  export
-    <uri-parse-error>;
-end;
+    $charset-user-info,
+    $charset-host,
+    $charset-path,
+    $charset-query,
+    $charset-fragment;
+end module;
+
+define module uri-internal
+  use byte-vector,
+    import: { copy-bytes };
+  use common-dylan,
+    exclude: { format-to-string };
+  use streams;
+  use strings;
+  use uri;
+end module;

--- a/sources/uri-test-suite-library.dylan
+++ b/sources/uri-test-suite-library.dylan
@@ -2,12 +2,14 @@ module: dylan-user
 
 define library uri-test-suite
   use common-dylan;
+  use io;
   use testworks;
   use uri;
-end;
+end library;
 
 define module uri-test-suite
   use common-dylan;
+  use format;
   use testworks;
   use uri;
-end;
+end module;

--- a/sources/uri-test-suite.dylan
+++ b/sources/uri-test-suite.dylan
@@ -1,244 +1,209 @@
 module: uri-test-suite
 
-define macro uri-reference-test-definer
-  { define uri-reference-test ?name:token
-      ?uri:token
-      ( ?scheme:token , ?authority:token ,
-        ?path:token , ?query:token ,
-        ?fragment:token )
-      => ?result:token
-   end
-  }
-   =>
-  {
-    define test "uri-reference-" ## ?name ()
-      let uri = parse-uri(?uri);
-      check-equal("scheme", uri.uri-scheme, ?scheme);
-      check-equal("authority", uri.uri-authority, ?authority);
-      check-equal("path", build-path(uri), ?path);
-      check-equal("query", build-query(uri), ?query);
-      check-equal("fragment", uri.uri-fragment, ?fragment);
-      let target-uri = transform-uris($base-uri, uri);
-      check-equal("target-uri", build-uri(target-uri), ?result);
-    end
-  }
-end macro;
+// TODO(cgay): copy the tests from some language that has a large user base and therefore
+// the URI code has been battle tested for edge cases.
 
-define constant $base-uri = parse-uri("http://a/b/c/d;p?q");
+define constant $base-uri = string-to-uri("http://a/b/c/d;p?q");
 
-define test uri-base-test ()
-  check-equal("base-uri scheme", $base-uri.uri-scheme, "http");
-  check-equal("base-uri authority", $base-uri.uri-authority, "a");
-  check-equal("base-uri path", build-path($base-uri), "/b/c/d;p");
-  check-equal("base-uri query", build-query($base-uri), "q");
-  check-equal("base-uri fragment", $base-uri.uri-fragment, "");
-end;
+define test test-string-to-uri-basic ()
+  assert-equal("http",     $base-uri.uri-scheme);
+  assert-equal("a",        $base-uri.uri-authority);
+  assert-equal("/b/c/d;p", $base-uri.uri-raw-path);
+  assert-equal(#("", "b", "c", "d;p"), $base-uri.uri-path);
+  assert-equal("q",        $base-uri.uri-raw-query);
+  assert-false($base-uri.uri-fragment);
+end test;
 
-define test uri-plus-decode-test ()
-  let uri = parse-uri("http://a/p?x=a+test");
-  check-equal("uri query x has a plus", uri.uri-query["x"], "a+test");
-  let url = parse-url("http://a/p?x=a+test");
-  check-equal("url query x has a space", url.uri-query["x"], "a test");
-end;
+define test test-percent-encode ()
+end test;
 
-define test uri-percent-encode-test ()
-  check-equal("percent encode space", percent-encode($uri-pchar, " "), "%20");
-end;
+define test test-percent-decode ()
+  let uri = string-to-uri("http://a/p?x=a%20test&y=it%27s");
+  assert-equal("x=a%20test&y=it%27s", uri.uri-raw-query);
+  assert-equal("a test", uri.uri-query["x"]);
+  assert-equal("it's", uri.uri-query["y"]);
 
-define test uri-percent-decode-test ()
-  let uri = parse-uri("http://a/p?x=a%20test&y=it%27s");
-  check-equal("uri query x", uri.uri-query["x"], "a test");
-  check-equal("uri query y", uri.uri-query["y"], "it's");
-end;
+  assert-signals(<uri-error>, percent-decode("%", strict?: #t));
+  assert-signals(<uri-error>, percent-decode("%a", strict?: #t));
+  assert-signals(<uri-error>, percent-decode("%ag", strict?: #t));
+  assert-equal("%", percent-decode("%"));
+  assert-equal("%a", percent-decode("%a"));
+  assert-equal("%ag", percent-decode("%ag"));
+  assert-equal("%ga", percent-decode("%ga"));
+  assert-equal("x@x", percent-decode("x%40x"));
+  assert-equal("x/x", percent-decode("x%2fx"));
+  assert-equal("x/x", percent-decode("x%2Fx"));
+end test;
 
-define uri-reference-test normal-test-1
-  "g:h" ("g", "", "h", "", "") => "g:h"
-end;
+define function check-uri-reference
+    (uri-string :: <string>,
+     #key scheme, user, host, port, path, query, fragment, merged :: <string>)
+  let uri = string-to-uri(uri-string);
+  expect-equal(scheme,   uri.uri-scheme);
+  expect-equal(user,     uri.uri-raw-user-info);
+  expect-equal(host,     uri.uri-raw-host);
+  expect-equal(port,     uri.uri-port);
+  expect-equal(path,     uri.uri-raw-path);
+  expect-equal(query,    uri.uri-raw-query);
+  expect-equal(fragment, uri.uri-raw-fragment);
+  let target-uri = merge-uris($base-uri, uri);
+  expect-equal(merged, uri-to-string(target-uri),
+               "%s merged against base URI %s = %s ?",
+               uri-string, uri-to-string($base-uri), merged);
+end function;
 
-define uri-reference-test normal-test-2
-  "g" ("", "", "g", "", "") => "http://a/b/c/g"
-end;
+// Normal Examples from
+// https://datatracker.ietf.org/doc/html/rfc3986#section-5.4.1
+define test test-normal-uri-reference-examples ()
+  check-uri-reference("g:h", scheme: "g", path: "h", merged: "g:h");
+  check-uri-reference("g",       path: "g",   merged: "http://a/b/c/g");
+  check-uri-reference("./g",     path: "./g", merged: "http://a/b/c/g");
+  check-uri-reference("g/",      path: "g/",  merged: "http://a/b/c/g/");
+  check-uri-reference("/g",      path: "/g",  merged: "http://a/g");
+  check-uri-reference("//g",     host: "g",   merged: "http://g");
+  check-uri-reference("?y",      query: "y",  merged: "http://a/b/c/d;p?y");
+  check-uri-reference("g?y",     path: "g", query: "y", merged: "http://a/b/c/g?y");
+  check-uri-reference("#s",      fragment: "s", merged: "http://a/b/c/d;p?q#s");
+  check-uri-reference("g#s",     path: "g", fragment: "s", merged: "http://a/b/c/g#s");
+  check-uri-reference("g?y#s",   path: "g", query: "y", fragment: "s",   merged: "http://a/b/c/g?y#s");
+  check-uri-reference(";x",      path: ";x", merged: "http://a/b/c/;x");
+  check-uri-reference("g;x",     path: "g;x", merged: "http://a/b/c/g;x");
+  check-uri-reference("g;x?y#s", path: "g;x", query: "y", fragment: "s", merged: "http://a/b/c/g;x?y#s");
+  check-uri-reference(".",       path: ".",       merged: "http://a/b/c/");
+  check-uri-reference("./",      path: "./",      merged: "http://a/b/c/");
+  check-uri-reference("..",      path: "..",      merged: "http://a/b/");
+  check-uri-reference("../",     path: "../",     merged: "http://a/b/");
+  check-uri-reference("../g",    path: "../g",    merged: "http://a/b/g");
+  check-uri-reference("../..",   path: "../..",   merged: "http://a/");
+  check-uri-reference("../../",  path: "../../",  merged: "http://a/");
+  check-uri-reference("../../g", path: "../../g", merged: "http://a/g");
+  // Note default port not included in merged result string, per RFC.
+  check-uri-reference("http://host:80", scheme: "http", host: "host", port: 80, merged: "http://host");
+  check-uri-reference("http://host:80/abc", scheme: "http", host: "host", port: 80, path: "/abc", merged: "http://host/abc");
+  check-uri-reference("http://host:77/abc", scheme: "http", host: "host", port: 77, path: "/abc", merged: "http://host:77/abc");
+end test;
 
-define uri-reference-test normal-test-3
-  "./g" ("", "", "./g", "", "") => "http://a/b/c/g"
-end;
+// Abnormal Examples from
+// https://datatracker.ietf.org/doc/html/rfc3986#section-5.4.2
+define test test-abnormal-uri-reference-examples ()
+  check-uri-reference("../../../g",    path: "../../../g",    merged: "http://a/g");
+  check-uri-reference("../../../../g", path: "../../../../g", merged: "http://a/g");
+  check-uri-reference("/./g",          path: "/./g",          merged: "http://a/g");
+  check-uri-reference("/../g",         path: "/../g",         merged: "http://a/g");
+  check-uri-reference("g.",            path: "g.",            merged: "http://a/b/c/g.");
+  check-uri-reference(".g",            path: ".g",            merged: "http://a/b/c/.g");
+  check-uri-reference("g..",           path: "g..",           merged: "http://a/b/c/g..");
+  check-uri-reference("..g",           path: "..g",           merged: "http://a/b/c/..g");
+  check-uri-reference("./../g",        path: "./../g",        merged: "http://a/b/g");
+  check-uri-reference("./g/.",         path: "./g/.",         merged: "http://a/b/c/g/");
+  check-uri-reference("g/./h",         path: "g/./h",         merged: "http://a/b/c/g/h");
+  check-uri-reference("g/../h",        path: "g/../h",        merged: "http://a/b/c/h");
+  check-uri-reference("g;x=1/./y",     path: "g;x=1/./y",     merged: "http://a/b/c/g;x=1/y");
+  check-uri-reference("g;x=1/../y",    path: "g;x=1/../y",    merged: "http://a/b/c/y");
+end test;
 
-define uri-reference-test normal-test-4
-  "g/" ("", "", "g/", "", "") => "http://a/b/c/g/"
-end;
+define test test-path-segment-normalization ()
+  let base = string-to-uri("ftp:/x/y?q");
+  local
+    method check-normalize-path (want, path)
+      let u = string-to-uri(path);
+      let m = merge-uris(base, u);
+      let p = join(m.uri-path, "/");
+      assert-equal(want, p, "normalize path %=", path);
+    end;
+  // All absolute paths so just resolving .. segments.
+  check-normalize-path("/a/c",   "/a/b/../c");
+  check-normalize-path("/a/b/c", "/a/b/./c");
+  check-normalize-path("/a/c",   "/a/./b/../c");
+  check-normalize-path("/b/c",   "/a/../b/./c");
+  check-normalize-path("/a/c",   "/a/b/./../c");
+  check-normalize-path("/a/c",   "/a/b/.././c");
+  check-normalize-path("/b/c",   "/a/../../../b/c");
 
-define uri-reference-test normal-test-5
-  "/g" ("", "", "/g", "", "") => "http://a/g"
-end;
-
-define uri-reference-test normal-test-6
-  "//g" ("", "g", "", "", "") => "http://g"
-end;
-
-define uri-reference-test normal-test-7
-  "?y" ("", "", "", "y", "") => "http://a/b/c/d;p?y"
-end;
-
-define uri-reference-test normal-test-8
-  "g?y" ("", "", "g", "y", "") => "http://a/b/c/g?y"
-end;
-
-define uri-reference-test normal-test-9
-  "#s" ("", "", "", "", "s") => "http://a/b/c/d;p?q#s"
-end;
-
-define uri-reference-test normal-test-10
-  "g#s" ("", "", "g", "", "s") => "http://a/b/c/g#s"
-end;
-
-define uri-reference-test normal-test-11
-  "g?y#s" ("", "", "g", "y", "s") => "http://a/b/c/g?y#s"
-end;
-
-define uri-reference-test normal-test-12
-  ";x" ("", "", ";x", "", "") => "http://a/b/c/;x"
-end;
-
-define uri-reference-test normal-test-13
-  "g;x" ("", "", "g;x", "", "") => "http://a/b/c/g;x"
-end;
-
-define uri-reference-test normal-test-14
-  "g;x?y#s" ("", "", "g;x", "y", "s") => "http://a/b/c/g;x?y#s"
-end;
-
-define uri-reference-test normal-test-15
-  "" ("", "", "", "", "") => "http://a/b/c/d;p?q"
-end;
-
-define uri-reference-test normal-test-16
-  "." ("", "", ".", "", "") => "http://a/b/c/"
-end;
-
-define uri-reference-test normal-test-17
-  "./" ("", "", "./", "", "") => "http://a/b/c/"
-end;
-
-define uri-reference-test normal-test-18
-  ".." ("", "", "..", "", "") => "http://a/b/"
-end;
-
-define uri-reference-test normal-test-19
-  "../" ("", "", "../", "", "") => "http://a/b/"
-end;
-
-define uri-reference-test normal-test-20
-  "../g" ("", "", "../g", "", "") => "http://a/b/g"
-end;
-
-define uri-reference-test normal-test-21
-  "../.." ("", "", "../..", "", "") => "http://a/"
-end;
-
-define uri-reference-test normal-test-22
-  "../../" ("", "", "../../", "", "") => "http://a/"
-end;
-
-define uri-reference-test normal-test-23
-  "../../g" ("", "", "../../g", "", "") => "http://a/g"
-end;
-
-define uri-reference-test has-port-test-1
-  "http://host:80" ("http", "host:80", "", "", "") => "http://host:80"
-end;
-
-define uri-reference-test has-port-test-2
-  "http://host:80/abc" ("http", "host:80", "/abc", "", "") => "http://host:80/abc"
-end;
-
-
-define uri-reference-test abnormal-test-1
-  "../../../g" ("", "", "../../../g", "", "") => "http://a/g"
-end;
-
-define uri-reference-test abnormal-test-2
-  "../../../../g" ("", "", "../../../../g", "", "") => "http://a/g"
-end;
-
-define uri-reference-test abnormal-test-3
-  "/./g" ("", "", "/./g", "", "") => "http://a/g"
-end;
-
-define uri-reference-test abnormal-test-4
-  "/../g" ("", "", "/../g", "", "") => "http://a/g"
-end;
-
-define uri-reference-test abnormal-test-5
-  "g." ("", "", "g.", "", "") => "http://a/b/c/g."
-end;
-
-define uri-reference-test abnormal-test-6
-  ".g" ("", "", ".g", "", "") => "http://a/b/c/.g"
-end;
-
-define uri-reference-test abnormal-test-7
-  "g.." ("", "", "g..", "", "") => "http://a/b/c/g.."
-end;
-
-define uri-reference-test abnormal-test-8
-  "..g" ("", "", "..g", "", "") => "http://a/b/c/..g"
-end;
-
-define uri-reference-test abnormal-test-9
-  "./../g" ("", "", "./../g", "", "") => "http://a/b/g"
-end;
-
-define uri-reference-test abnormal-test-10
-  "./g/." ("", "", "./g/.", "", "") => "http://a/b/c/g/"
-end;
-
-define uri-reference-test abnormal-test-11
-  "g/./h" ("", "", "g/./h", "", "") => "http://a/b/c/g/h"
-end;
-
-define uri-reference-test abnormal-test-12
-  "g/../h" ("", "", "g/../h", "", "") => "http://a/b/c/h"
-end;
-
-define uri-reference-test abnormal-test-13
-  "g;x=1/./y" ("", "", "g;x=1/./y", "", "") => "http://a/b/c/g;x=1/y"
-end;
-
-define uri-reference-test abnormal-test-14
-  "g;x=1/../y" ("", "", "g;x=1/../y", "", "") => "http://a/b/c/y"
-end;
-
-define test uri-path-segment-normalization-test ()
-  check-equal("path", "/a/c", remove-dot-segments("/a/b/../c"));
-  check-equal("path", "/a/b/c", remove-dot-segments("/a/b/./c"));
-  check-equal("path", "/a/c", remove-dot-segments("/a/./b/../c"));
-  check-equal("path", "/b/c", remove-dot-segments("/a/../b/./c"));
-  check-equal("path", "/a/c", remove-dot-segments("/a/b/./../c"));
-  check-equal("path", "/a/c", remove-dot-segments("/a/b/.././c"));
-  check-equal("path", "/b/c", remove-dot-segments("/a/../../../b/c"));
-
-  check-equal("path", "a/c", remove-dot-segments("a/b/../c"));
-  check-equal("path", "a/b/c", remove-dot-segments("a/b/./c"));
-  check-equal("path", "a/c", remove-dot-segments("a/./b/../c"));
-  check-equal("path", "b/c", remove-dot-segments("a/../b/./c"));
-  check-equal("path", "a/c", remove-dot-segments("a/b/./../c"));
-  check-equal("path", "a/c", remove-dot-segments("a/b/.././c"));
-  check-equal("path", "b/c", remove-dot-segments("a/../../../b/c"));
-end;
+  // Relative paths so actual path merging happens.
+  check-normalize-path("/x/a/c",    "a/b/../c");
+  check-normalize-path("/x/a/b/c",  "a/b/./c");
+  check-normalize-path("/x/a/c",    "a/./b/../c");
+  check-normalize-path("/x/b/c",    "a/../b/./c");
+  check-normalize-path("/x/a/c",    "a/b/./../c");
+  check-normalize-path("/x/a/c",    "a/b/.././c");
+  check-normalize-path("/b/c",      "a/../../../b/c");
+end test;
 
 define test parse-error-test ()
   for (uri in #["http://host:xx/abc"])
-    assert-signals(<uri-parse-error>, parse-uri(uri), uri);
+    assert-signals(<uri-parse-error>, string-to-uri(uri), uri);
   end;
-end test parse-error-test;
+end test;
 
-define test split-query-test ()
-  let t = make(<string-table>);
-  t["a"] := #t;
-  t["b"] := #("3", "2");
-  t["c"] := #(#t, "4");
-  t["d"] := "5";
-  assert-equal(split-query("a&b=2&b=3&c=4&c&d=5"), t);
-end;
+define test test-uri-query-value ()
+  let u = make(<uri>, raw-query: "a&b=2&b=3&c=4&c&d=5&e=%26");
+  assert-equal(#t, uri-query-value(u, "a"));
+  // Technically we don't guarantee an order, so this could change.
+  assert-equal("3",         uri-query-value(u, "b"));
+  assert-equal(#("3", "2"), uri-query-value(u, "b", all?: #t));
+  assert-equal(#(#t, "4"),  uri-query-value(u, "c", all?: #t));
+  assert-equal("5",         uri-query-value(u, "d"));
+  assert-equal("&",         uri-query-value(u, "e"));
+end test;
 
-run-test-application()
+define test test-scheme ()
+  assert-signals(<uri-parse-error>, string-to-uri("://foo.com"),
+                 "URI may not start with ':'");
+
+  // Check some invalid chars.
+  for (char in "%/&,")
+    let string = format-to-string("a%cb://c.d", char);
+    assert-signals(<uri-parse-error>, string-to-uri(string),
+                   "scheme may not contain %=", char);
+  end;
+
+  // Check the valid non-ALPHA chars.
+  for (char in "+-.")
+    let string = format-to-string("a%cb://c.d", char);
+    assert-no-errors(string-to-uri(string),
+                     "scheme may not contain %=", char);
+  end;
+
+  // Leading char must be ALPHA.
+  for (char in "+-7")
+    let string = format-to-string("%cabc://c.d", char);
+    assert-signals(<uri-parse-error>, string-to-uri(string),
+                   "scheme must start with A-Z");
+  end;
+
+  // Scheme isn't required to be lowercased but it must be compared without regard to
+  // case and should be lowercase in constructed URI strings, so we store it in
+  // lowercase.
+  assert-equal("ftp", uri-scheme(string-to-uri("FTP:/a")),
+               "scheme lowercased?");
+end test;
+
+define test test-authority ()
+  let u = string-to-uri("http://user:p%40ss@host.org");
+  assert-equal("user:p%40ss", u.uri-raw-user-info);
+  assert-equal("user:p@ss", u.uri-user-info);
+  assert-equal("host.org", u.uri-host);
+  assert-equal("user:p@ss@host.org", uri-authority(u));
+  assert-equal("user:p%40ss@host.org", uri-authority(u, percent-encoded?: #t));
+
+  let u1 = string-to-uri("//%61.org/a/b#4");
+  assert-equal("%61.org", u1.uri-raw-host);
+  assert-equal("a.org", u1.uri-host);
+
+  let u2 = string-to-uri("https://[aa::bb]:123/foo");
+  assert-equal("[aa::bb]", u2.uri-host);
+  assert-equal(123, u2.uri-port);
+
+  let u3 = string-to-uri("https://1.2.3.4:123/foo");
+  assert-equal("1.2.3.4", u3.uri-host);
+  assert-equal(123, u3.uri-port);
+
+  let u4 = string-to-uri("//[aa::bb]/foo");
+  assert-equal("[aa::bb]", u4.uri-host);
+  assert-false(u4.uri-port);
+
+  let u5 = string-to-uri("https://1.2.3.4/foo");
+  assert-equal("1.2.3.4", u5.uri-host);
+  assert-equal(443, u5.uri-port);
+end test;

--- a/sources/uri-test-suite.lid
+++ b/sources/uri-test-suite.lid
@@ -1,4 +1,4 @@
 library: uri-test-suite
-target-type: executable
+target-type: dll
 files: uri-test-suite-library.dylan
        uri-test-suite.dylan

--- a/sources/uri.dylan
+++ b/sources/uri.dylan
@@ -1,29 +1,220 @@
-module: uri
-author: Bastian Mueller
-synopsis: RFC 3986: Uniform Resource Identifier (URI): Generic Syntax
+Module: uri-internal
+Synopsis: RFC 3986: Uniform Resource Identifier (URI): Generic Syntax
 Copyright:    Original Code is Copyright (c) 2018 Dylan Hackers
               All rights reserved.
 License:      See License.txt in this distribution for details.
 
-define class <uri> (<object>)
-  slot uri-scheme :: <string> = "",
-    init-keyword: scheme:;
-  slot uri-userinfo :: <string> = "",
-    init-keyword: userinfo:;
-  slot uri-host :: <string> = "",
-    init-keyword: host:;
-  slot uri-port :: false-or(<integer>) = #f,
-    init-keyword: port:;
-  // Do you really want this to be a stretchy type?
-  slot uri-path :: <sequence> = make(<deque>),
-    init-keyword: path:;
-  // keys without values are #t
-  // (I think #f would work better as the null value. --cgay)
-  slot uri-query :: false-or(<string-table>) = #f,
-    init-keyword: query:;
-  slot uri-fragment :: <string> = "",
-    init-keyword: fragment:;
-end class <uri>;
+// RFC 3986: https://datatracker.ietf.org/doc/html/rfc3986
+
+// Brevity
+define constant <string?> = false-or(<string>);
+define constant <integer?> = false-or(<integer>);
+
+
+define open class <uri> (<object>)
+  // For slots that have %foo and %raw-foo varieties, the raw slot is percent encoded and
+  // the other is not.  If one of them is supplied at init time the other will be
+  // computed from it.
+
+  // Always lowercased if the URI was created by string-to-uri.
+  constant slot %scheme :: <string?> = #f, init-keyword: scheme:;
+
+  slot %raw-user-info :: <string?> = #f, init-keyword: raw-user-info:;
+  slot %user-info     :: <string?> = #f, init-keyword: user-info:;
+
+  // Host, always lowercased if the URI was created by string-to-uri.
+  slot %raw-host :: <string?> = #f, init-keyword: raw-host:;
+  slot %host     :: <string?> = #f, init-keyword: host:;
+
+  constant slot %port :: <integer?> = #f, init-keyword: port:;
+
+  slot %raw-path :: <string?> = #f, init-keyword: raw-path:;
+  // The path is stored as a list of percent-decoded path segments, as created by
+  // `split(path, '/')`.  As a consequence, #() can be used to indicate that this slot
+  // hasn't yet been set from `%raw-path`.
+  slot %path :: <list> = #(), init-keyword: path:;
+
+  // The original URI query string (no leading '?').
+  slot %raw-query :: <string?> = #f, init-keyword: raw-query:;
+  // Map of query percent-decoded keys to percent-decoded values, computed lazily in
+  // `uri-query`.  Values can be one of three types: (1) string, (2) singleton(#t), (3)
+  // list with no guaranteed order. Examples:
+  //
+  //   Query string    "k"s value
+  //   "k=v"           "v"
+  //   "k="            ""
+  //   "k"             #t  (so that #f can indicate k doesn't exist at all)
+  //   "k=a&k=b"       #("a", "b") or #("b", "a")
+  slot %query :: false-or(<string-table>) = #f, init-keyword: query:;
+
+  slot %raw-fragment :: <string?> = #f, init-keyword: raw-fragment:;
+  slot %fragment     :: <string?> = #f, init-keyword: fragment:;
+end class;
+
+
+// --------------------------------------------------------------------------------
+// Exported generic functions
+
+// uri-path, uri-query, and uri-query-value are the only open generics because they're
+// the only ones with interesting enough implementations for which I (cgay) can imagine
+// someone wanting to provide alternatives. We'll see.
+
+define sealed generic uri-scheme        (uri :: <uri>) => (scheme :: <string?>);
+define sealed generic uri-user-info     (uri :: <uri>) => (info :: <string?>);
+define sealed generic uri-raw-user-info (uri :: <uri>) => (info :: <string?>);
+define sealed generic uri-host          (uri :: <uri>) => (host :: <string?>);
+define sealed generic uri-raw-host      (uri :: <uri>) => (host :: <string?>);
+define sealed generic uri-port          (uri :: <uri>) => (port :: <integer?>);
+define open   generic uri-path          (uri :: <uri>) => (path :: <object>);
+define sealed generic uri-raw-path      (uri :: <uri>) => (path :: <string?>);
+define open   generic uri-query         (uri :: <uri>) => (query :: <object>);
+define sealed generic uri-raw-query     (uri :: <uri>) => (query :: <string?>);
+define sealed generic uri-fragment      (uri :: <uri>) => (frag :: <string?>);
+define sealed generic uri-raw-fragment  (uri :: <uri>) => (frag :: <string?>);
+
+// Get the value associated with a given key in the URI query.  A key may appear in a URI
+// query more than once.  To retrieve all values for a key (as a list) use `all?: #t`.
+// With `all?: #f` (the default) only one (arbitrary) value is returned.
+define open generic uri-query-value
+    (uri :: <uri>, key :: <string>, #key all?) => (value :: <object>);
+
+define sealed generic uri-authority
+    (uri :: <uri>, #key percent-encoded?) => (authority :: <string?>);
+
+define sealed generic has-authority?
+    (uri :: <uri>) => (_ :: <boolean>);
+
+
+define sealed generic percent-encode
+    (string :: <byte-string>, charset :: <table>) => (encoded :: <byte-string>);
+define sealed generic percent-decode
+    (string :: <byte-string>, #key strict?) => (unencoded :: <byte-string>);
+
+
+define open generic merge-uris
+    (base :: <uri>, reference :: <uri>, #key strict?) => (target :: <uri>);
+
+
+// --------------------------------------------------------------------------------
+// Implementation
+
+define inline method uri-scheme (u :: <uri>) => (scheme :: <string?>)
+  u.%scheme
+end method;
+
+define inline method uri-raw-user-info (u :: <uri>) => (info :: <string?>)
+  if (~u.%raw-user-info & u.%user-info)
+    u.%raw-user-info := percent-encode(u.%user-info, $charset-user-info);
+  end;
+  u.%raw-user-info
+end method;
+
+define inline method uri-user-info (u :: <uri>) => (info :: <string?>)
+  if (~u.%user-info & u.%raw-user-info)
+    u.%user-info := percent-decode(u.%raw-user-info);
+  end;
+  u.%user-info
+end method;
+
+define inline method  uri-raw-host (u :: <uri>) => (host :: <string?>)
+  if (~u.%raw-host & u.%host)
+    u.%raw-host := percent-encode(u.%host, $charset-host);
+  end;
+  u.%raw-host
+end method;
+
+define inline method  uri-host (u :: <uri>) => (host :: <string?>)
+  if (~u.%host & u.%raw-host)
+    u.%host := percent-decode(u.%raw-host);
+  end;
+  u.%host
+end method;
+
+define inline method uri-port (u :: <uri>) => (port :: <integer?>)
+  u.%port
+end method;
+
+define inline method uri-raw-path (u :: <uri>) => (path :: <string?>)
+  if (~u.%raw-path & ~empty?(u.%path))
+    u.%raw-path := percent-encode(join(u.%path, "/"), $charset-path);
+  end;
+  u.%raw-path
+end method;
+
+// The default implementation returns the segments, but subclassers may decide to return
+// a percent decoded string, a <path> object, etc.
+define method uri-path (u :: <uri>) => (path :: <list>)
+  // Note that split("", '/') => #("") and split("/", '/') => #("", "") so empty? means
+  // %path hasn't been computed yet.
+  if (empty?(u.%path) & u.%raw-path)
+    let path = map(percent-decode, split(u.%raw-path, '/'));
+    if (u.%scheme)
+      // A scheme means URI is absolute, by definition, and we remove dot segments.
+      path := remove-dot-segments(path);
+    end;
+    u.%path := path
+  end;
+  u.%path
+end method;
+
+define inline method uri-raw-query (u :: <uri>) => (query :: <string?>)
+  u.%raw-query
+    | if (u.%query)
+        // query: was provided but raw-query: wasn't.  No order is guaranteed here.
+        u.%raw-query := query-values-to-string(u.%query);
+      end
+end method;
+
+define function query-values-to-string (qvalues :: <table>) => (query :: <string>)
+  let keyvals = #();
+  for (v keyed-by k :: <string> in qvalues)
+    select (v by instance?)
+      singleton(#t) => push(k, keyvals);
+      <string>      => push(concatenate(k, "=", v), keyvals);
+      <list>        => for (v in v)
+                         push(if (v == #t) k else concatenate(k, "=", v) end,
+                              keyvals);
+                       end;
+    end select;
+  end for;
+  join(keyvals, "&")
+end function;
+
+define inline method  uri-query (u :: <uri>) => (qvalues :: false-or(<string-table>))
+  u.%query | (u.%query := u.%raw-query & split-query(u.%raw-query))
+end method;
+
+define method uri-query-value
+    (u :: <uri>, key :: <string>, #key all? :: <boolean>)
+ => (value :: <object>)
+  let qvalues = u.uri-query;
+  if (qvalues)
+    let value = element(qvalues, key, default: #f);
+    if (instance?(value, <list>))
+      if (all?)
+        value
+      else
+        value.head
+      end
+    else
+      value
+    end
+  end
+end method;
+
+define inline method  uri-raw-fragment (u :: <uri>) => (fragment :: <string?>)
+  if (~u.%raw-fragment & u.%fragment)
+    u.%raw-fragment := percent-encode(u.%fragment, $charset-fragment);
+  end;
+  u.%raw-fragment
+end method;
+
+define inline method  uri-fragment (u :: <uri>) => (fragment :: <string?>)
+  if (~u.%fragment & u.%raw-fragment)
+    u.%fragment := percent-decode(u.%raw-fragment);
+  end;
+  u.%fragment
+end method;
 
 // FIXME -- Implement the following restrictions in the initialize method
 //          for the <uri> class...
@@ -35,249 +226,331 @@ end class <uri>;
 //   component.
 //   Need an error class for these.  e.g., <invalid-uri-error>
 
-define class <url> (<uri>)
-end;
+define class <uri-error> (<simple-error>) end;
+define class <uri-parse-error> (<uri-error>) end;
 
-define class <uri-error> (<error>)
-end;
+define inline function uri-error
+    (format-string :: <string>, #rest format-args)
+  signal(make(<uri-error>,
+              format-string: format-string,
+              format-arguments: format-args));
+end function;
 
-define class <uri-parse-error> (<uri-error>)
-end;
-
-define function parse-error
-    (input :: <string>, pos :: <integer>, msg :: <string>)
- => ()
+define inline function uri-parse-error
+    (format-string :: <string>, #rest format-args)
   signal(make(<uri-parse-error>,
-              format-string: "Error parsing URI %= at index %d: %s",
-              format-arguments: list(input, pos, msg)));
-end;
+              format-string: format-string,
+              format-arguments: format-args));
+end function;
 
-define method has-authority-part?
-    (uri :: <uri>) => (has-it? :: <boolean>)
-  ~empty?(uri.uri-userinfo) | ~empty?(uri.uri-host) | (uri.uri-port ~= #f)
-end method has-authority-part?;
-
+define inline method has-authority?
+    (uri :: <uri>) => (_ :: <boolean>)
+  (uri.%host | uri.%raw-host) & #t // host is a required part of the authority
+end method;
 
 // RFC 3986, Section 3.2
 //       authority   = [ userinfo "@" ] host [ ":" port ]
 define method uri-authority
-    (uri :: <uri>)
- => (result :: <string>)
-  let result = "";
-  unless (empty?(uri.uri-userinfo))
-    result := concatenate(result, percent-encode($uri-userinfo, uri.uri-userinfo), "@");
+    (uri :: <uri>, #key percent-encoded? :: <boolean>) => (authority :: <string?>)
+  if (has-authority?(uri))
+    let uinfo = if (percent-encoded?) uri.uri-raw-user-info else uri.uri-user-info end;
+    let host = if (percent-encoded?) uri.uri-raw-host else uri.uri-host end;
+    // URI producers and normalizers should omit the port component and its ":" delimiter
+    // if port is empty or if its value would be the same as that of the scheme's
+    // default.  https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.3
+    let port = if (uri.%port
+                     & ~(uri.%scheme
+                           & (uri.%port == default-port-for-scheme(uri.%scheme))))
+                 uri.%port
+               end;
+    concatenate(uinfo | "",
+                if (uinfo) "@" else "" end,
+                host,
+                if (port) ":" else "" end,
+                if (port) integer-to-string(port) else "" end)
+  end
+end method;
+
+define function default-port-for-scheme (scheme :: <string>) => (port :: <integer?>)
+  select (scheme by string-equal?)
+    // This list was taken from
+    // https://gist.github.com/mahmoud/2fe281a8daaff26cfe9c15d2c5bf5c8b and I removed the
+    // null entries.
+    "acap"     => 674;
+    "afp"      => 548;
+    "dict"     => 2628;
+    "dns"      => 53;
+    "ftp"      => 21;
+    "git"      => 9418;
+    "gopher"   => 70;
+    "http"     => 80;
+    "https"    => 443;
+    "imap"     => 143;
+    "ipp"      => 631;
+    "ipps"     => 631;
+    "irc"      => 194;
+    "ircs"     => 6697;
+    "ldap"     => 389;
+    "ldaps"    => 636;
+    "mms"      => 1755;
+    "msrp"     => 2855;
+    "mtqp"     => 1038;
+    "nfs"      => 111;
+    "nntp"     => 119;
+    "nntps"    => 563;
+    "pop"      => 110;
+    "prospero" => 1525;
+    "redis"    => 6379;
+    "rsync"    => 873;
+    "rtsp"     => 554;
+    "rtsps"    => 322;
+    "rtspu"    => 5005;
+    "sftp"     => 22;
+    "smb"      => 445;
+    "snmp"     => 161;
+    "ssh"      => 22;
+    "svn"      => 3690;
+    "telnet"   => 23;
+    "ventrilo" => 3784;
+    "vnc"      => 5900;
+    "wais"     => 210;
+    "ws"       => 80;
+    "wss"      => 443;
+    otherwise => #f;
+  end
+end function;
+
+
+define function %charset (#rest contents) => (cs :: <table>)
+  let charset = make(<table>);
+  for (item in contents)
+    select (item by instance?)
+      <string> =>
+        for (char in item)
+          charset[char] := as(<integer>, char);
+        end;
+      <table> =>
+        for (v keyed-by char in item)
+          charset[char] := v
+        end;
+    end select;
+  end for;
+  charset
+end function;
+
+// Collected ABNF for URI: https://datatracker.ietf.org/doc/html/rfc3986#appendix-A
+
+define constant $charset-alphanumeric :: <table>
+  = %charset("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
+define constant $charset-sub-delims :: <table> = %charset("\'!$&()*+,;=");
+define constant $charset-unreserved :: <table> = %charset($charset-alphanumeric, "-._~");
+define constant $charset-segment    :: <table> = %charset($charset-unreserved,
+                                                          $charset-sub-delims, ":@");
+define constant $charset-scheme     :: <table> = %charset($charset-alphanumeric, "+-.");
+define constant $charset-user-info  :: <table> = %charset($charset-unreserved,
+                                                          $charset-sub-delims, ":");
+define constant $charset-host       :: <table> = %charset($charset-unreserved,
+                                                          $charset-sub-delims, "%");
+define constant $charset-path       :: <table> = %charset($charset-alphanumeric,
+                                                          "-._~%/", $charset-sub-delims);
+define constant $charset-query      :: <table> = %charset($charset-segment, "/?");
+define constant $charset-fragment   :: <table> = $charset-query;
+
+define function validate
+    (uri :: <string>, part-name :: <string>, result :: <string>, charset :: <table>,
+     #key empty-ok? = #f)
+  if (~empty-ok? & empty?(result))
+    uri-parse-error("invalid URI %s - %s must not be empty", uri, part-name);
   end;
-  result := concatenate(result, uri.uri-host | "");
-  if (uri.uri-port)
-    result := concatenate(result, ":", integer-to-string(uri.uri-port));
-  end if;
-  result;
-end method uri-authority;
+  for (ch in result)
+    if (~element(charset, ch, default: #f))
+      uri-parse-error("invalid URI %s - %s may not contain character %c",
+                      uri, part-name, ch);
+    end;
+  end;
+end function;
 
-define constant $alpha :: <byte-string>
-  = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-    "abcdefghijklmnopqrstuvwxyz";
+// Not clear if all this ad-hoc parsing code is worth avoiding a dependency on regex, but
+// here we are.  Regex: https://datatracker.ietf.org/doc/html/rfc3986#appendix-B
 
-define constant $digit :: <byte-string> = "0123456789";
-
-//define constant $uri-scheme :: <byte-string> = concatenate($alpha, $digit, "+-.");
-//define constant $uri-gen-delims :: <byte-string> = ":/?#[]@"";
-define constant $uri-sub-delims :: <byte-string> = "\'!$&()*+,;=";
-//define constant $uri-reserved :: <byte-string> = concatenate($uri-gen-delims, $uri-sub-delims);
-define constant $uri-unreserved :: <byte-string> = concatenate($alpha, $digit, "-._~");
-define constant $uri-pchar :: <byte-string> = concatenate($uri-unreserved, $uri-sub-delims, ":@");
-define constant $uri-userinfo :: <byte-string> = concatenate($uri-unreserved, $uri-sub-delims, ":");
-define constant $uri-query :: <byte-string> = concatenate($uri-pchar, "/?");
-define constant $uri-query-no-plus :: <byte-string> = remove($uri-query, '+');
-//define constant $uri-port = $digit;
-define constant $uri-segment = $uri-pchar;
-//define constant $uri-fragment = $uri-query;
-
-define inline function parse-scheme
+define function parse-scheme
     (uri :: <string>)
- => (scheme :: false-or(<string>), next-index :: <integer>)
-  let scheme-end = find-any(uri, method (c) c == ':' end);
+ => (scheme :: <string?>, next-index :: <integer>)
+  let scheme-end = find-any(uri, curry(\==, ':'));
   if (scheme-end)
-    values(copy-sequence(uri, start: 0, end: scheme-end), scheme-end + 1)
+    let scheme = lowercase!(copy-sequence(uri, end: scheme-end));
+    validate(uri, "scheme", scheme, $charset-scheme, empty-ok?: #f);
+    if (~alphabetic?(scheme[0]))
+      uri-parse-error("invalid URI %s - scheme must start with an alphabetic character",
+                      uri);
+    end;
+    values(scheme, scheme-end + 1)
   else
     values(#f, 0)
   end
-end function parse-scheme;
+end function;
 
-define inline function parse-authority
+define function parse-authority
     (uri :: <string>, start :: <integer>)
- => (userinfo :: false-or(<string>),
-     host :: <string>,
-     port :: false-or(<integer>),
+ => (user-info :: <string?>, host :: <string?>, port :: <integer?>,
      next-index :: <integer>)
+  // `start` is the character following "//".
   let stop = uri.size;
-  let userinfo :: false-or(<string>) = #f;
-  let host :: <string> =  "";
-  let port :: false-or(<integer>) = #f;
-
-  let userinfo-end = find-any(uri, method (c) c == '@' end, start: start);
-  let authority-end = find-any(uri, method (c) c == '/' end, start: start);
-  if (authority-end & userinfo-end & userinfo-end < authority-end)
-    // parse userinfo
-    userinfo := copy-sequence(uri, start: start, end: userinfo-end);
-  end if;
-  let host-start = userinfo-end | start;
-  let port-start = find-any(uri, method (c) c == ':' end, start: host-start);
-  if (port-start)
-    let bpos :: <integer> = port-start + 1;
-    let epos :: <integer> = authority-end | stop;
-    if (port-start + 1 >= epos)
-      parse-error(uri, port-start, "invalid port");
-    else
-      let port-string = copy-sequence(uri, start: bpos, end: epos);
-      block ()
-        port := string-to-integer(port-string);
-      exception (ex :: <error>)
-        parse-error(uri, bpos, "invalid port");
+  let user :: <string?> = #f;
+  let host :: <string?> =  #f;
+  let port :: <integer?> = #f;
+  let auth-end = find-any(uri, rcurry(member?, "/?#"), start: start) | stop;
+  if (start == auth-end)
+    values(#f, #f, #f, start)
+  else
+    let user-end = find-any(uri, curry(\==, '@'), start: start, end: auth-end);
+    if (user-end & user-end < auth-end)
+      user := copy-sequence(uri, start: start, end: user-end);
+    end;
+    let host-start = if (user-end) user-end + 1 else start end;
+    let port-start = find-any(uri, curry(\==, ':'),
+                              start: host-start, end: auth-end, from-end?: #t);
+    // There's a lot more we could do to validate the host, but we leave it up to the
+    // protocol level, e.g., when an HTTP client tries to convert it to an IP address.
+    if (uri[host-start] == '[')
+      let close = find-any(uri, curry(\==, ']'),
+                           start: host-start, end: auth-end, from-end?: #t);
+      if ((port-start | 0) < (close | 0))
+        port-start := #f;
+      end;
+      if (~close | (port-start & uri[port-start - 1] ~== ']'))
+        uri-parse-error("invalid URI - bad IPv6+ host:port in %s", uri);
       end;
     end;
-  end;
-  // parse host
-  host := copy-sequence(uri, start: host-start, end: port-start | authority-end | stop);
+    let host = lowercase!(copy-sequence(uri, start: host-start,
+                                        end: port-start | auth-end));
+    if (empty?(host))
+      uri-parse-error("invalid URI host - if authority present host must not"
+                        " be empty: %s", uri);
+    end;
+    if (port-start)
+      let bpos :: <integer> = port-start + 1;
+      if (bpos < auth-end)
+        let port-string = copy-sequence(uri, start: bpos, end: auth-end);
+        block ()
+          port := string-to-integer(port-string);
+        exception (<error>)
+          uri-parse-error("invalid URI port at index %d in %s", bpos, uri);
+        end;
+      else
+        uri-parse-error("invalid URI port at index %d in %s", port-start, uri);
+      end if;
+    end if;
+    // TODO(cgay): validate(uri, "authority", ...)
+    values(user, host, port, auth-end | stop)
+  end if;
+end function;
 
-  values(userinfo, host, port, authority-end | stop)
-end function parse-authority;
-
-define inline function parse-path
+define function parse-path
     (uri :: <string>, start :: <integer>)
- => (path :: false-or(<string>), next-index :: <integer>)
-  let stop = uri.size;
-  let path-end = find-any(uri, method (c) c == '?' | c == '#' end, start: start) | stop;
+ => (path :: <string?>, next-index :: <integer>)
+  let path-end
+    = find-any(uri, method (c) c == '?' | c == '#' end, start: start)
+        | uri.size;
   if (start < path-end)
-    values(copy-sequence(uri, start: start, end: path-end), path-end)
+    let path = copy-sequence(uri, start: start, end: path-end);
+    validate(uri, "path", path, $charset-path);
+    values(path, path-end)
   else
     values(#f, start)
   end if
-end function parse-path;
+end function;
 
-define inline function parse-query
+define function parse-query
     (uri :: <string>, start :: <integer>)
- => (query :: false-or(<string>), next-index :: <integer>)
-  let stop = uri.size;
-  if (start < stop)
-    if (uri[start] == '?')
-      let query-end = find-any(uri, method (c) c == '#' end, start: start + 1) | stop;
-      values(copy-sequence(uri, start: start + 1, end: query-end), query-end)
+ => (query :: <string?>, next-index :: <integer>)
+  if (uri[start] == '?')
+    let start = start + 1;
+    let stop = uri.size;
+    if (start < stop)
+      let query-end = find-any(uri, curry(\==, '#'), start: start) | stop;
+      values(copy-sequence(uri, start: start, end: query-end), query-end)
     else
       values(#f, start)
-    end if
+    end
   else
     values(#f, start)
-  end if
-end function parse-query;
+  end
+end function;
 
-define inline function parse-fragment
+define function parse-fragment
     (uri :: <string>, start :: <integer>)
- => (fragment :: false-or(<string>))
+ => (fragment :: <string?>)
   let stop = uri.size;
-  if (start < stop)
-    // probably not necessary
-    if (uri[start] == '#')
-      copy-sequence(uri, start: start + 1, end: stop)
-    else
-      #f
-    end if
-  else
-    #f
-  end if
-end function parse-fragment;
+  if (start < stop & uri[start] == '#')
+    copy-sequence(uri, start: start + 1, end: stop)
+  end
+end function;
 
-define function %parse-uri
-    (uri :: <string>)
- => (scheme :: false-or(<string>),
-     userinfo :: false-or(<string>),
-     host :: false-or(<string>),
-     port :: false-or(<integer>),
-     path :: false-or(<string>),
-     query :: false-or(<string>),
-     fragment :: false-or(<string>))
-  let stop = uri.size;
+define function string-to-uri
+    (string :: <string>) => (uri :: <uri>)
+  let (scheme, user, host, port, path, query, fragment) = split-uri(string);
+  make(<uri>,
+       scheme: scheme,
+       raw-user-info: user,
+       raw-host: host,
+       port: port,
+       raw-path: path,
+       raw-query: query,
+       raw-fragment: fragment)
+end function;
 
-  let (scheme :: false-or(<string>), scheme-end :: <integer>)
-    = if (starts-with?(uri, "//"))
+define function split-uri
+    (string :: <string>)
+ => (scheme :: <string?>, user :: <string?>, host :: <string?>, port :: <integer?>,
+     path :: <string?>, query :: <string?>, fragment :: <string?>)
+  let stop = string.size;
+  let authority? = starts-with?(string, "//");
+  let (scheme :: <string?>, scheme-end :: <integer>)
+    = if (authority?)
         values(#f, 0)
       else
-        parse-scheme(uri)
-      end if;
-
-  if (starts-with?(copy-sequence(uri, start: scheme-end), "//"))
-    // parse authority path-abempty
-    let (userinfo, host, port, authority-end)
-      = parse-authority(uri, scheme-end + 2);
-    let (path, path-end) = parse-path(uri, authority-end);
-    let (query, query-end) = parse-query(uri, path-end);
-    let (fragment, fragment-end) = parse-fragment(uri, query-end);
-    values(scheme, userinfo, host, port, path, query, fragment)
-  else
-    // parse path-absolute, path-noscheme or path-empty
-    let (path, path-end) = parse-path(uri, scheme-end);
-    let (query, query-end) = parse-query(uri, path-end);
-    let fragment = parse-fragment(uri, query-end);
-    values(scheme, #f, #f, #f, path, query, fragment)
-  end if
-end function %parse-uri;
-
-define method parse-uri-as
-    (class :: subclass(<uri>), uri :: <string>)
- => (result :: <uri>)
-  let (scheme, userinfo, host, port, path, query, fragment)
-    = if (empty?(uri))
-        values(#f, #f, #f, #f, #f, #f, #f)
+        parse-scheme(string)
+      end;
+  authority?
+    := string-equal?(string, "//", start1: scheme-end, end1: min(stop, scheme-end + 2));
+  let (user, host, port, auth-end)
+    = if (authority?)
+        parse-authority(string, scheme-end + 2)
       else
-        %parse-uri(uri)
-      end if;
+        values(#f, #f, #f, scheme-end)
+      end;
+  if (scheme & ~port)
+    port := default-port-for-scheme(scheme);
+  end;
+  let (path, path-end) = parse-path(string, auth-end);
+  // https://datatracker.ietf.org/doc/html/rfc3986#section-3.3
+  if (authority? & path & path[0] ~== '/')
+    uri-parse-error("invalid URI: %s - path must be empty or start with '/'"
+                      " when authority present", string);
+  end;
+  if (authority? & path & starts-with?(path, "//"))
+    uri-parse-error("invalid URI: %s - path may not start with '//'"
+                    " when authority present", string);
+  end;
+  let (query, query-end)
+    = if (path-end < stop)
+        parse-query(string, path-end)
+      else
+        values(#f, path-end)
+      end;
+  let fragment = parse-fragment(string, query-end);
+  values(scheme, user, host, port, path, query, fragment)
+end function;
 
-  if (class == <url> & query)
-    query := replace-substrings(query, "+", " ");
-  end if;
-  if (scheme) scheme := percent-decode(scheme); end;
-  if (userinfo) userinfo := percent-decode(userinfo); end;
-  if (host) host := percent-decode(host); end;
-  if (fragment) fragment := percent-decode(fragment); end;
-  let uri = make(class,
-                 scheme: scheme | "",
-                 userinfo: userinfo | "",
-                 host: host | "",
-                 port: port,
-                 fragment: fragment | "");
-  if (path & ~empty?(path))
-    uri.uri-path := split-path(path);
-  end if;
-  if (query)
-    uri.uri-query := split-query(query);
-  end if;
-  if (absolute?(uri))
-    uri.uri-path := remove-dot-segments(uri.uri-path);
-  end if;
-  uri;
-end method parse-uri-as;
-
-define constant parse-uri = curry(parse-uri-as, <uri>);
-
-define constant parse-url = curry(parse-uri-as, <url>);
-
-// relative / absolute
-
-define function relative?
-    (uri :: <uri>)
- => (result :: <boolean>);
-  empty?(uri.uri-scheme)
-end;
-
-define constant absolute? = complement(relative?);
-
-// split parts
-
-define method split-path
-    (path :: <string>)
- => (parts :: <sequence>)
-  map(percent-decode, split(path, '/'))
-end;
+// "A URI-reference is either a URI or a relative reference.  If the URI-reference's
+// prefix does not match the syntax of a scheme followed by its colon separator, then the
+// URI-reference is a relative reference."
+// https://datatracker.ietf.org/doc/html/rfc3986#section-4.1
+define function uri-relative?
+    (uri :: <uri>) => (relative? :: <boolean>)
+  ~uri.%scheme
+end function;
 
 // Even though the RFC states that:
 // "3.4.  Query
@@ -285,292 +558,320 @@ end;
 //   data in the path component (Section 3.3), serves to identify a
 //   resource within the scope of the URI's scheme and naming authority
 //   (if any)."
-// We split the query into key-values, where "&foo=&" is different from &foo&.
+// https://datatracker.ietf.org/doc/html/rfc3986#section-3.4
+// We split the query into key-values, where "&foo=&" is different from "&foo&".
 // The former sets the qvalue to "" and the latter sets it to #t.
-define method split-query (query :: <string>) => (parts :: <string-table>);
-  let parts = split(query, "&");
-  let table = make(<string-table>, size: parts.size);
-  for (part in parts)
+define method split-query (query :: <string>) => (values :: <string-table>)
+  let keyvals = split(query, '&');
+  let qvalues = make(<string-table>, size: keyvals.size);
+  for (kv in keyvals)
     let (qname, qvalue)
-      = apply(values, split(part, "=", remove-if-empty?: #f, count: 2));
+      = apply(values, split(kv, '=', remove-if-empty?: #f, count: 2));
     qname := percent-decode(qname);
-    qvalue := if (qvalue) percent-decode(qvalue) else #t end;
-    let v = element(table, qname, default: #f);
-    table[qname] := select (v by instance?)
-                      <string>, singleton(#t) => list(qvalue, v);
-                      // Should we reverse these at the end to preserve order?
-                      <list> => pair(qvalue, v);
-                      singleton(#f) => qvalue;
-                    end;
+    qvalue := if (qvalue)
+                percent-decode(qvalue) // "?k=&..."
+              else
+                #t              // "?k&..."
+              end;
+    let existing = element(qvalues, qname, default: $unfound);
+    qvalues[qname] := if (existing == $unfound)
+                        qvalue
+                      elseif (instance?(existing, <list>))
+                        pair(qvalue, existing)
+                      else
+                        list(qvalue, existing)
+                      end;
   end for;
-  table
+  qvalues
 end method;
 
-define method as
-    (class == <string>, uri :: <uri>)
- => (result :: <string>)
-  build-uri(uri)
-end method as;
-
-// build-uri
-
-// Turn a uri into a string
-define open generic build-uri
-    (uri :: <uri>, #key include-scheme, include-authority)
- => (result :: <string>);
-
-define method build-uri
-    (uri :: <uri>,
-     #key include-scheme = #t, include-authority = #t)
- => (result :: <string>)
+// Do we want an option to produce a non-encoded URI?
+define function uri-to-string
+    (uri :: <uri>, #key scheme? = #t, authority? = #t)
+ => (string :: <string>)
+  authority? := authority? & uri.has-authority?;
   let parts :: <stretchy-vector> = make(<stretchy-vector>);
-  if (include-scheme & ~empty?(uri.uri-scheme))
-    add!(parts, uri.uri-scheme);
+  if (scheme? & uri.%scheme)
+    add!(parts, uri.%scheme);
     add!(parts, ":")
   end;
-  if (include-authority & has-authority-part?(uri))
+  if (authority?)
     add!(parts, "//");
-    add!(parts, uri.uri-authority);
+    add!(parts, uri-authority(uri, percent-encoded?: #t));
   end;
-  add!(parts, build-path(uri));
-  unless (~uri.uri-query | empty?(uri.uri-query))
+  let p = uri.uri-raw-path;
+  if (p)
+    if (authority? & ~starts-with?(p, "/"))
+      add!(parts, "/");
+    end;
+    add!(parts, p);
+  end;
+  let q = uri.uri-raw-query;
+  if (q)
     add!(parts, "?");
-    add!(parts, build-query(uri));
+    add!(parts, q);
   end;
-  unless (empty?(uri.uri-fragment))
+  if (uri.uri-raw-fragment)
     add!(parts, "#");
-    add!(parts, uri.uri-fragment);
+    add!(parts, uri.uri-raw-fragment);
   end;
-  join(parts, "")
-end method build-uri;
+  apply(concatenate, parts)
+end function;
 
-// build-path
+// --------------------------------------------------------------------------------
+// Percent encoding / decoding
 
-define method build-path
-    (uri :: <uri>)
- => (encoded-path :: <string>)
-  if (empty?(uri.uri-path))
-    ""
-  else
-    join(map(curry(percent-encode, $uri-segment),
-             uri.uri-path),
-         "/")
-  end if;
-end;
+// TODO(cgay):
+// https://cs.opensource.google/go/go/+/refs/tags/go1.26.4:src/net/url/gen_encoding_table.go;l=148
+// is a pretty useful resource for percent encoding.
 
-// build-query
+define constant $hex-digits :: <byte-string> = "0123456789ABCDEF";
+define constant $zero-code    :: <integer> = as(<integer>, '0');
+define constant $nine-code    :: <integer> = as(<integer>, '9');
+define constant $upper-a-code :: <integer> = as(<integer>, 'A');
+define constant $upper-f-code :: <integer> = as(<integer>, 'F');
+define constant $lower-a-code :: <integer> = as(<integer>, 'a');
 
-define method build-query
-    (uri :: <uri>) => (encoded-query :: <string>)
-  build-query-internal(uri, $uri-query)
-end;
+define inline function hex-value (char :: <character>) => (hex-value :: <integer>)
+  // char is a hex digit [0-9a-fA-F]
+  let code :: <integer> = as(<integer>, char);
+  select (as(<integer>, char) by \<=)
+    $nine-code    => code - $zero-code;
+    $upper-f-code => code - $upper-a-code + 10;
+    otherwise     => code - $lower-a-code + 10;
+  end
+end function;
 
-define method build-query
-    (url :: <url>) => (encoded-query :: <string>)
-  build-query-internal(url, $uri-query-no-plus)
-end;
-
-define method build-query-internal
-    (uri :: <uri>, chars-not-to-encode :: <sequence>)
- => (encoded-query :: <string>)
-  if (~uri.uri-query | empty?(uri.uri-query))
-    ""
-  else
-    let parts = make(<stretchy-vector>);
-    for (value keyed-by key in uri.uri-query)
-      key := percent-encode(chars-not-to-encode, key);
-      add-key-value(parts, key, value);
-    end for;
-    join(parts, "&")
-  end if;
-end method build-query-internal;
-
-define method add-key-value
-    (parts :: <stretchy-vector>, key :: <string>, value :: <string>)
- => (parts :: <stretchy-vector>);
-  add!(parts, concatenate(key, "=", percent-encode($uri-query, value)));
-end;
-
-define method add-key-value
-    (parts :: <stretchy-vector>, key :: <string>, value == #t)
- => (parts :: <stretchy-vector>)
-  add!(parts, key);
-end;
-
-define method add-key-value
-    (parts :: <stretchy-vector>, key :: <string>, values :: <list>)
- => (parts :: <stretchy-vector>);
-  for (value in values)
-    add-key-value(parts, key, value);
-  end for;
-  parts;
-end;
-
-
-// percent-encode
-
+// Return a string in which any character in `string` that isn't a member of `charset` is
+// percent encoded.  Returns `string` if no percent encoding needed, otherwise makes a
+// copy.
 define method percent-encode
-    (chars :: <byte-string>, unencoded :: <byte-string>)
- => (encoded :: <string>)
-  let encoded = "";
-  for (char in unencoded)
-    encoded := concatenate(encoded, if (member?(char, chars))
-                                      list(char)
-                                    else
-                                      format-to-string("%%%X", as(<byte>, char))
-                                    end if);
-  end for;
-  encoded;
-end method percent-encode;
-
-// percent-decode
+    (string :: <byte-string>, charset :: <table>) => (encoded :: <byte-string>)
+  let indexes = #();
+  let n = 0;
+  for (c in string, i from 0)
+    if (~element(charset, c, default: #f))
+      n := n + 1;
+      indexes := pair(i, indexes);
+    end;
+  end;
+  if (n == 0)
+    string
+  else
+    let encoded = make(<byte-string>, size: string.size + n * 2);
+    let len = string.size;
+    iterate loop (i-string = 0, i-encoded = 0, indexes = reverse!(indexes))
+      if (i-string < len)
+        let index = indexes.head;
+        if (i-string == index)
+          let code = as(<integer>, string[i-string]);
+          encoded[i-encoded] := '%';
+          encoded[i-encoded + 1] := $hex-digits[ash(code, -4)];
+          encoded[i-encoded + 2] := $hex-digits[logand(code, #x0F)];
+          loop(i-string + 1, i-encoded + 3, indexes.tail)
+        else
+          encoded[i-encoded] := string[i-string];
+          loop(i-string + 1, i-encoded + 1, indexes)
+        end
+      end
+    end iterate;
+    encoded
+  end if
+end method;
 
 define method percent-decode
-    (encoded :: <byte-string>)
- => (unencoded :: <string>);
-  let result = make(limited(<stretchy-vector>, of: <byte-character>));
-  let (decode?, ignore?) = values(#f, #f);
-  for (char in encoded, position from 0)
-    if (ignore?)
-      ignore? := #f;
-    else
-      if (char = '%' & ~decode?)
-        decode? := #t;
-      else
-        if (decode? & size(encoded) > position + 1)
-          let encoded-char = make(<byte-string>, size: 2);
-          encoded-char[0] := char;
-          encoded-char[1] := encoded[position + 1];
-          let decoded-char = as(<byte-character>,
-                                string-to-integer(encoded-char, base: 16));
-          ignore? := #t;
-          decode? := #f;
-          add!(result, decoded-char);
+    (string :: <byte-string>, #key strict? :: <boolean>) => (unencoded :: <byte-string>)
+  if (~member?('%', string))
+    string
+  else
+    with-output-to-string (stream)
+      let prev1 = #f;           // two chars behind ch
+      let prev2 = #f;           // one char behind ch
+      for (ch in string,
+           i from 0)
+        if (prev1 == '%')
+          // Are prev1, prev2, and ch % HEX HEX ?
+          if (hexadecimal-digit?(prev2) & hexadecimal-digit?(ch))
+            write-element(stream, as(<byte-character>,
+                                     ash(hex-value(prev2), 4) + hex-value(ch)));
+          elseif (strict?)
+            uri-parse-error("invalid URI percent escape at character %= in %s",
+                            i, string);
+          else
+            write-element(stream, prev1);
+            write-element(stream, prev2);
+            write-element(stream, ch);
+          end;
+          prev1 := #f; prev2 := #f;
         else
-          add!(result, char);
-        end if;
-      end if;
-    end if;
-  end for;
-  as(<string>, result)
-end method percent-decode;
+          prev1 & write-element(stream, prev1);
+          prev1 := prev2;
+          prev2 := ch;
+        end;
+      end for;
+      if (strict? & (prev1 == '%' | prev2 == '%'))
+        uri-parse-error("invalid URI percent escape at end of %=", string);
+      else
+        prev1 & write-element(stream, prev1);
+        prev2 & write-element(stream, prev2);
+      end;
+    end with-output-to-string
+  end if
+end method;
 
-// remove-dot-segments
-
-define generic remove-dot-segments (path :: <object>) => (result :: <object>);
-
-define method remove-dot-segments (path :: <string>) => (result :: <string>);
-  let path = split(path, "/", remove-if-empty?: #f);
-  path := remove-dot-segments(path);
-  join(path, "/")
-end;
-
-define method remove-dot-segments (path :: <sequence>) => (result :: <sequence>);
-  let input = make(<deque>);
-  do(curry(push-last, input), path);
-  let output = make(<deque>);
-  for (segment in input, i from 0)
-    let last? = (i = size(input) - 1);
-    if ((segment = "." | segment = "") & last?)
-      push-last(output, "");
-    elseif (segment = ".." & last?)
-      last(output) := "";
-    elseif (segment = "..")
-      if (size(output) > 0 & last(output) ~= "")
-        pop-last(output);
-      end if;
-    elseif (segment = ".")
-    else
-      push-last(output, segment);
-    end if;
-  end for;
-  output;
-end;
+// --------------------------------------------------------------------------------
+// Transform References (merge URIs)
 
 // 5.2.2.  Transform References
 // "Merges" a base and reference URI
-// A leading empty component in the path indicates that it's absolute.
+// A leading '/' in the path indicates that it's absolute.
 // Logic taken directly from the pseudeocode
-define method transform-uris
-    (base :: <uri>, reference :: <uri>,
-     #key as :: subclass(<uri>) = <uri>)
+define method merge-uris
+    (base :: <uri>, reference :: <uri>, #key strict? :: <boolean> = #t)
  => (target :: <uri>)
-  local method merge (base, reference)
-      if (has-authority-part?(base) & empty?(base.uri-path))
-        concatenate(#(""), reference.uri-path);
-      else
-        concatenate(copy-sequence(base.uri-path, end: base.uri-path.size - 1),
-                    reference.uri-path)
-      end if;
-    end;
-  let target = make(as);
-  if (~empty?(reference.uri-scheme))
-    // If the reference uri has a scheme then it is fully-qualified and
-    // is used in its entirety, except for the fragment.  (If <uri> were
-    // immutable we could just return the original.)
-    target.uri-scheme := reference.uri-scheme;
-    target.uri-userinfo := reference.uri-userinfo;
-    target.uri-host := reference.uri-host;
-    target.uri-port := reference.uri-port;
-    target.uri-path := remove-dot-segments(reference.uri-path);
-    target.uri-query := reference.uri-query;
-  else
-    if (has-authority-part?(reference))
-      target.uri-userinfo := reference.uri-userinfo;
-      target.uri-host := reference.uri-host;
-      target.uri-port := reference.uri-port;
-      target.uri-path := remove-dot-segments(reference.uri-path);
-      target.uri-query := reference.uri-query;
-    else
-      // reference's scheme and authority were both empty...
-      if (empty?(reference.uri-path))
-        target.uri-path := base.uri-path;
-        target.uri-query := if (~reference.uri-query | empty?(reference.uri-query))
-                              base.uri-query
-                            else
-                              reference.uri-query
-                            end;
-      else
-        target.uri-path := if (first(reference.uri-path) = "")
-                             remove-dot-segments(reference.uri-path)
-                           else
-                             remove-dot-segments(merge(base, reference))
-                           end;
-        target.uri-query := reference.uri-query;
-      end if;
-      target.uri-userinfo := base.uri-userinfo;
-      target.uri-host := base.uri-host;
-      target.uri-port := base.uri-port;
-    end if;
-    target.uri-scheme := base.uri-scheme;
-  end if;
-  target.uri-fragment := reference.uri-fragment;
-  target;
-end method transform-uris;
+  // TODO(cgay): (optional) normalize (6.2.2) base first
 
-define method print-message (uri :: <uri>, stream :: <stream>) => ()
-  format(stream, "%s", build-uri(uri))
-end;
+  // https://datatracker.ietf.org/doc/html/rfc3986#section-5.2.1
+  base.%scheme
+    | uri-error("cannot merge against base URI without a scheme: %s",
+                uri-to-string(base));
+  let ref :: <uri> = reference; // brevity
+  let (scheme, user, host, port, path, query) = #f;
+  let ref-scheme = ref.uri-scheme;
+  if (~strict? & ref.uri-scheme = base.uri-scheme)
+    ref-scheme := #f            // effectively undefine scheme(R)
+  end;
+  // This is a direct translation of
+  // https://datatracker.ietf.org/doc/html/rfc3986#section-5.2.2
+  // Note the use of the public APIs here to ensure that a value is available if
+  // at least one of the raw/non-raw slots is non-false.
+  if (ref-scheme)
+    // If the reference URI has a scheme then it is fully-qualified and is used as-is,
+    // except for dropping the fragment and removing dot segments from the path.
+    // https://datatracker.ietf.org/doc/html/rfc3986#section-4.3
+    scheme := ref.uri-scheme;
+    user := ref.uri-raw-user-info;
+    host := ref.uri-raw-host;
+    port := ref.uri-port;
+    path := ref.uri-raw-path;
+    query := ref.uri-raw-query;
+  else
+    if (ref.has-authority?)
+      user := ref.uri-raw-user-info;
+      host := ref.uri-raw-host;
+      port := ref.uri-port;
+      path := ref.uri-raw-path;
+      query := ref.uri-raw-query;
+    else
+      if (~ref.uri-raw-path)
+        path := base.uri-raw-path;
+        query := ref.uri-raw-query | base.uri-raw-query;
+      else
+        path := remove-dot-segments(if (starts-with?(ref.uri-raw-path, "/"))
+                                      ref.uri-raw-path
+                                    else
+                                      merge-raw-paths(base, ref)
+                                    end);
+        query := ref.uri-raw-query;
+      end;
+      user := base.uri-raw-user-info;
+      host := base.uri-raw-host;
+      port := base.uri-port;
+    end;
+    scheme := base.uri-scheme;
+  end;
+  make(<uri>,
+       scheme: scheme,
+       raw-user-info: user,
+       raw-host: host,
+       port: port,
+       raw-path: path,
+       raw-query: query,
+       raw-fragment: ref.uri-raw-fragment) // always from ref
+end method merge-uris;
+
+define function merge-raw-paths
+    (base :: <uri>, ref :: <uri>) => (path :: <byte-string>)
+  // https://datatracker.ietf.org/doc/html/rfc3986#section-5.2.3
+  if (base.has-authority? & ~base.%raw-path)
+    // Use ref path but make it absolute.  (Seems this can result in "//" at the
+    // beginning of the path, but it is what the RFC says to do so....)
+    concatenate("/", ref.%raw-path | "")
+  else
+    let slash = base.%path & find-any(base.%raw-path, curry(\==, '/'), from-end?: #t);
+    if (~slash)
+      ref.%raw-path
+    else
+      let prefix = copy-sequence(base.%raw-path, end: slash + 1);
+      concatenate(prefix, ref.%raw-path | "")
+    end
+  end
+end function;
+
+// https://datatracker.ietf.org/doc/html/rfc3986#section-5.2.4
+define method remove-dot-segments
+    (path :: <string>) => (new-path :: <string>)
+  if (~member?('.', path))
+    path
+  else
+    join(remove-dot-segments(split(path, '/')), "/")
+  end
+end method;
+
+define method remove-dot-segments
+    (segments :: <list>) => (new-path :: <list>)
+  if (~member?("..", segments, test: \=) & ~member?(".", segments, test: \=))
+    segments
+  else
+    as(<list>, remove-dot-segments(as(<deque>, segments)))
+  end
+end method;
+
+define method remove-dot-segments
+    (segments :: <deque>) => (new-path :: <deque>)
+  let result = make(<deque>);
+  let len = size(segments);
+  for (seg in segments, i from 0)
+    let last? = (i = len - 1);
+    select (seg by \=)
+      "." =>
+        if (last?)
+          push-last(result, "");  // /a/b/. => /a/b/
+        end;
+      ".." =>
+        if (last?)
+          last(result) := "";   // /a/b/.. => /a/
+        elseif (result.size > 0 & ~empty?(last(result)))
+          pop-last(result);
+        end if;
+      otherwise =>
+        push-last(result, seg);
+    end select;
+  end for;
+  result
+end method;
 
 /*
+
+TODO(cgay): verify that these examples are in the tests and delete this comment.
 
 // example / usage / testing
 
 begin
   let bar = "/foo?users=admin&users=1&users=2&members=3&members=4&comment=&add=Add";
   let foo = parse-url(bar);
-  format-out("%=, %=\n", foo.uri-query["users"], foo.uri-query["members"]);
+  format-out("%=, %=\n", foo.%query["users"], foo.%query["members"]);
   format-out("%s\n%s\n", bar, foo);
 
   let foo = parse-url("http://baz.blub/pat%2fh/test?fo%20o=ba%2f%20r");
-  format-out("%s, %=,%s\n", foo.uri-query, foo.uri-path, foo);
+  format-out("%s, %=,%s\n", foo.%query, foo.%path, foo);
 
   format-out("%s\n", split-query("foo=bar+blub&baz"));
 
   let uri = parse-uri("http://foo:bar@baz.blub:23/path/test/../page?fo%20=ba+r&q1=q2&q3=&q4#extra");
   let url = parse-url("http://foo:bar@baz.blub:23/path/test/../page?fo%20o=b+r&q1=q2&q3=&q4#extra");
-  format-out("%=\n", uri.uri-query);
-  format-out("%=\n", url.uri-query);
+  format-out("%=\n", uri.%query);
+  format-out("%=\n", url.%query);
 
   format-out("%=\n", percent-decode("foo%20bar"));
   format-out("%=\n", percent-decode("%2"));
@@ -579,13 +880,13 @@ begin
 
   let uri = parse-uri("http://foo:bar@baz.blub:23/path/test/../page?foo=bar&q1=q2#extra");
   format-out("%s\n", build-uri(uri));
-  uri := make(<uri>, scheme: "http", userinfo: "foo@bar:blub");
+  uri := make(<uri>, scheme: "http", user: "foo@bar:blub");
   format-out("%s\n", build-uri(uri));
   uri := make(<uri>, scheme: "http", host: "foobar", path: "/p1/p2/p3", query: "k1=v1&k2=v2");
-  last(uri.uri-path) := "foo/bar+baz";
+  last(uri.%path) := "foo/bar+baz";
   format-out("%s\n", build-uri(uri));
   let url = make(<url>, scheme: "http", host: "foobar", path: "/p1/p2/p3", query: "k1=v1&k2=v2");
-  last(url.uri-path) := "foo/bar+baz";
+  last(url.%path) := "foo/bar+baz";
   format-out("%s\n", build-uri(url));
 
   let uri1 = parse-uri("http://foo.bar/test");


### PR DESCRIPTION
* `<uri>` is now immutable outside the uri module (no setters exported).
* `<uri>` is subclassable to override the behavior of path and query elements.
* Most slots have "raw" variants that are percent encoded.
* Most slots are `false-or(<string>)` now, not ""; this is more standard Dylan style
* `uri-query-value` should be used to access query values.
* Scheme is now validated (does not allow invalid characters)
* More invalid URIs are rejected
* Some support for IP literals in authority has been added.  Full validation of the
  syntax is left to the protocol level.
* It is no longer valid to merge URIs with different schemes.

This is a draft PR because there is more documentation to write and more validation (e.g., correct character sets?) should be done in parsing.  But I think it's ready for at least an API review if someone has time.